### PR TITLE
Incorporated global header and footer for pages

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function Footer() {
+    return (
+        <div className="items-center">
+            <hr></hr>
+            <footer className="flex justify-center items-center">
+                <Link className="text-blue-500 hover:underline cursor-pointer font-bold" href="/">Home</Link>
+                    <span className="px-1">|</span>
+                <Link className="text-blue-500 hover:underline cursor-pointer font-bold" href="/data-types">Data Types</Link>
+            </footer>
+            <div className="flex justify-center">
+                <p className="text-sm">&copy; Copyright by:</p>
+                <span className="px-1"> </span>
+                <p className="italic text-bold text-sm">Alexander Kalaj</p>
+            </div>
+        </div>
+    )
+}

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -1,0 +1,16 @@
+import Footer from "./footer";
+import Navbar from "./navbar";
+
+interface LayoutProps {
+    children: React.ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+    return (
+        <>
+            <Navbar />
+            <main>{children}</main>
+            <Footer />
+        </>
+    );
+}

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function Navbar() {
+    return (
+        <>
+            <nav className="flex ">
+                    <p className="font-bold text-xl">Learning Typescript | 
+                    <Link className="px-1 text-xl text-blue-500 hover:underline cursor-pointer font-bold" href="/">Home</Link>
+                    <Link className="px-1 text-xl text-blue-500 hover:underline cursor-pointer font-bold" href="/data-types">Data Types</Link></p>
+                <div>
+                    
+                </div>
+            </nav>
+            <hr></hr>
+        </>
+    )
+}

--- a/components/layout/nested-layout.tsx
+++ b/components/layout/nested-layout.tsx
@@ -1,0 +1,15 @@
+// Create a new layout component that wraps the children in a div with a class name of "nested-layout"
+
+interface NestedLayoutProps {
+    children: React.ReactNode;
+}
+
+export default function NestedLayout({ children }: NestedLayoutProps) {
+    return (
+        <div className="nested-layout">{children}</div>
+    );
+}
+
+// Path: components/layout/layout.tsx
+// Update the Layout component to include the NestedLayout component
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,19 @@
-import '@/styles/globals.css'
+import type { ReactElement, ReactNode } from 'react'
+import type { NextPage } from 'next'
 import type { AppProps } from 'next/app'
-
-export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+import '@/styles/globals.css'
+ 
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode
+}
+ 
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout
+}
+ 
+export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  // Use the layout defined at the page level, if available
+  const getLayout = Component.getLayout ?? ((page) => page)
+ 
+  return getLayout(<Component {...pageProps} />)
 }

--- a/pages/data-types/index.tsx
+++ b/pages/data-types/index.tsx
@@ -1,0 +1,22 @@
+import type { ReactElement } from 'react';
+import Layout from '@/components/layout/layout';
+import NestedLayout from '@/components/layout/nested-layout';
+import type { NextPageWithLayout } from '@/pages/_app';
+
+const DataTypesPage: NextPageWithLayout = () => {
+    return (
+        <div className="py-4 items-center text-center">
+            <h1>This is the data types page</h1>
+        </div>
+    );
+};
+
+DataTypesPage.getLayout = function getLayout(page: ReactElement) {
+    return (
+        <Layout>
+            <NestedLayout>{page}</NestedLayout>
+        </Layout>
+    );
+};
+
+export default DataTypesPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,23 @@
-export default function Home() {
+import type { ReactElement } from 'react'
+import Layout from '../components/layout/layout'
+import NestedLayout from '../components/layout/nested-layout'
+import type { NextPageWithLayout } from './_app'
+
+
+const Page: NextPageWithLayout = () => {
   return (
-    <div>
-      <p>Learning Typescript</p>
+    <div className="py-4 items-center text-center">
+      <p>Kaka de Nunes</p>
     </div>
   )
 }
+ 
+Page.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      <NestedLayout>{page}</NestedLayout>
+    </Layout>
+  )
+}
+ 
+export default Page

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,8 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
+
+body {
+  color: rgb(var(--foreground-rgb));
+  background: linear-gradient(
+      to bottom,
+      transparent,
+      rgb(var(--background-end-rgb))
+    )
+    rgb(var(--background-start-rgb));
 }


### PR DESCRIPTION
In an effort to learn how Header and Footers work with Typescript, I modified the base application to the spec detailed on the [NextJS Routing Guide](https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts).